### PR TITLE
ZRR-55 Add: 공통 예외 처리 핸들러 수정 및 성공 응답시 반환 작성

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/dto/CommonResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/dto/CommonResponse.kt
@@ -1,0 +1,17 @@
+package kr.zziririt.zziririt.api.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+data class CommonResponse<T>(
+    var code: Int,
+    var message: String? = null,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    var content: T? = null
+) {
+    companion object {
+        fun of(code: Int) = CommonResponse<Nothing>(code)
+        fun of(code: Int, message: String) = CommonResponse<Nothing>(code, message)
+        fun <T> of(code: Int, content: T) = CommonResponse(code, content = content)
+        fun <T> of(code: Int, message: String, content: T) = CommonResponse(code, message, content)
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/global/ApiHelper.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/ApiHelper.kt
@@ -1,0 +1,39 @@
+package kr.zziririt.zziririt.global
+
+import kr.zziririt.zziririt.api.dto.CommonResponse
+import kr.zziririt.zziririt.global.exception.CustomException
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.dto.ErrorResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+fun responseEntity(httpStatus: HttpStatus) =
+    ResponseEntity.status(httpStatus).body(CommonResponse.of(code = httpStatus.value()))
+
+fun <T> responseEntity(httpStatus: HttpStatus, func: () -> T) =
+    func.invoke()
+        .let {
+            ResponseEntity
+                .status(httpStatus)
+                .body(
+                    CommonResponse.of(code = httpStatus.value(), content = it)
+                )
+        }
+
+fun <T> responseEntity(httpStatus: HttpStatus, message: String, func: () -> T) =
+    func.invoke().let {
+        ResponseEntity
+            .status(httpStatus)
+            .body(
+                CommonResponse.of(code = httpStatus.value(), message = message, content = it)
+            )
+    }
+
+fun responseEntity(e: CustomException): ResponseEntity<Any> = if (e.message == null) {
+    ResponseEntity.status(e.errorCode.httpStatus).body(ErrorResponse.of(e.errorCode))
+} else {
+    ResponseEntity.status(e.errorCode.httpStatus).body(ErrorResponse.of(e.errorCode, e.message))
+}
+
+fun <T> responseEntity(errorCode: ErrorCode, payload: T): ResponseEntity<Any> =
+    ResponseEntity.status(errorCode.httpStatus).body(ErrorResponse.of(errorCode, payload))

--- a/src/main/kotlin/kr/zziririt/zziririt/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/exception/ErrorCode.kt
@@ -3,10 +3,12 @@ package kr.zziririt.zziririt.global.exception
 import org.springframework.http.HttpStatus
 
 enum class ErrorCode(
-    val code: Long,
+    val code: Int,
     val httpStatus: HttpStatus,
     val message: String
 ) {
+    UNAUTHORIZED(1001, HttpStatus.UNAUTHORIZED, "해당 API에 대한 권한이 없습니다."),
+
     NOT_IMAGE_FILE_EXTENSION(6101, HttpStatus.BAD_REQUEST, "png, jpeg, jpg 파일만 업로드 가능합니다."),
 
     VALIDATION(9001, HttpStatus.BAD_REQUEST, "Validation을 통과하지 못했습니다."),

--- a/src/main/kotlin/kr/zziririt/zziririt/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/exception/GlobalExceptionHandler.kt
@@ -1,7 +1,7 @@
 package kr.zziririt.zziririt.global.exception
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kr.zziririt.zziririt.global.exception.dto.ErrorResponse
+import kr.zziririt.zziririt.global.responseEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
@@ -16,13 +16,9 @@ private val kLogger = KotlinLogging.logger {}
 @RestControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
     @ExceptionHandler(CustomException::class)
-    fun handleCustomExceptionHandler(e: CustomException): ResponseEntity<Any>? {
+    fun handleCustomExceptionHandler(e: CustomException): ResponseEntity<Any> {
         kLogger.warn { "handleCustomExceptionHandler: ${e.errorCode.code}-${e.errorCode.message}" }
-        return if (e.message == null) {
-            ResponseEntity.status(e.errorCode.httpStatus).body(ErrorResponse.from(e.errorCode))
-        } else {
-            ResponseEntity.status(e.errorCode.httpStatus).body(ErrorResponse.from(e.errorCode, e.message))
-        }
+        return responseEntity(e)
     }
 
     override fun handleMethodArgumentNotValid(
@@ -34,7 +30,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         val errorCode = ErrorCode.VALIDATION
         kLogger.warn { "handleMethodArgumentNotValid: ${errorCode.code}-${errorCode.message}" }
 
-        return ResponseEntity.status(errorCode.httpStatus).body(ErrorResponse.from(errorCode, e.getErrorMap()))
+        return responseEntity(errorCode, e.getErrorMap())
     }
 
     private fun MethodArgumentNotValidException.getErrorMap(): Map<String, String?> =

--- a/src/main/kotlin/kr/zziririt/zziririt/global/exception/dto/ErrorResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/exception/dto/ErrorResponse.kt
@@ -3,30 +3,33 @@ package kr.zziririt.zziririt.global.exception.dto
 import com.fasterxml.jackson.annotation.JsonInclude
 import kr.zziririt.zziririt.global.exception.ErrorCode
 
-data class ErrorResponse(
-	val code: Long,
-	val message: String,
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	val payload: Any? = null
+data class ErrorResponse<T>(
+    val code: Int,
+    val message: String,
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val payload: T? = null
 ) {
-	companion object {
-		fun from(errorCode: ErrorCode) : ErrorResponse = ErrorResponse(
-			code = errorCode.code,
-			message = errorCode.message
-		)
-		fun from(errorCode: ErrorCode, message: String) : ErrorResponse = ErrorResponse(
-			code = errorCode.code,
-			message = message
-		)
-		fun from(errorCode: ErrorCode, payload: Any?) : ErrorResponse = ErrorResponse(
-			code = errorCode.code,
-			message = errorCode.message,
-			payload = payload
-		)
-		fun from(errorCode: ErrorCode, message: String, payload: Any?) : ErrorResponse = ErrorResponse(
-			code = errorCode.code,
-			message = message,
-			payload = payload
-		)
-	}
+    companion object {
+        fun of(errorCode: ErrorCode): ErrorResponse<Nothing> = ErrorResponse(
+            code = errorCode.code,
+            message = errorCode.message
+        )
+
+        fun of(errorCode: ErrorCode, message: String): ErrorResponse<Nothing> = ErrorResponse(
+            code = errorCode.code,
+            message = message
+        )
+
+        fun <T> of(errorCode: ErrorCode, payload: T) = ErrorResponse(
+            code = errorCode.code,
+            message = errorCode.message,
+            payload = payload
+        )
+
+        fun <T> of(errorCode: ErrorCode, message: String, payload: T) = ErrorResponse(
+            code = errorCode.code,
+            message = message,
+            payload = payload
+        )
+    }
 }


### PR DESCRIPTION
1. ErrorCode - code Type Long에서 Int로 변경
2. ErrorResponse - code Type Long에서 Int로 변경 및 Generic 추가, 정적 팩토리 메서드 of 수정
3. GlobalExceptionHandler - responseEntity ApiHelper 추가로 인한 변경
4. ApiHelper - Response 반환 규격 통일 및 정리
5. CommonResponse - 성공 응답에 대한 반환 타입 정의