### PR TITLE
ZRR-53 Test: Post Entity 단위 Test Code 작성 및 메서드 버그 수정

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntity.kt
@@ -51,7 +51,11 @@ class PostEntity(
 
     fun incrementHit() = this.hit++
 
-    fun togglePrivateStatus() = !this.privateStatus
+    fun togglePrivateStatus() {
+        this.privateStatus = !privateStatus
+    }
 
-    fun toggleBlindStatus() = !this.privateStatus
+    fun toggleBlindStatus() {
+        this.blindStatus = !blindStatus
+    }
 }

--- a/src/test/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntityTest.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntityTest.kt
@@ -1,0 +1,55 @@
+package kr.zziririt.zziririt.domain.post.model
+
+import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.matchers.shouldBe
+import kr.zziririt.zziririt.domain.member.model.MemberRole
+import kr.zziririt.zziririt.domain.member.model.OAuth2Provider
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+
+class PostEntityTest : FeatureSpec({
+    val socialMember = SocialMemberEntity("email", "nickname", OAuth2Provider.TEST, "providerId", MemberRole.VIEWER)
+    val board = BoardEntity(socialMember = socialMember, boardName = "자유 게시판")
+    val postFixture = PostEntity(board, socialMember, "title", "content")
+
+    feature("Post Entity update 메서드 정상 동작 검증") {
+        scenario("update 메서드를 사용하여 title과 content를 변경시 정상적으로 변경되어야 한다.") {
+            postFixture.update("updated Title", "updated Content")
+        }
+    }
+    feature("Post Entity incrementZzirit 메서드 정상 동작 검증") {
+        scenario("incrementZzirit 메서드를 사용할 경우 Post Entity의 ZziritCount가 1증가하여야 한다.") {
+            val beforeZziritCount = postFixture.zziritCount
+
+            postFixture.incrementZzirit()
+
+            postFixture.zziritCount shouldBe beforeZziritCount + 1
+        }
+    }
+    feature("Post Entity incrementHit 메서드 정상 동작 검증") {
+        scenario("incrementHit 메서드를 사용할 경우 Post Entity의 hit이 1증가하여야 한다.") {
+            val beforeHit = postFixture.hit
+
+            postFixture.incrementHit()
+
+            postFixture.hit shouldBe beforeHit + 1
+        }
+    }
+    feature("Post Entity togglePrivateStatus 메서드 정상 동작 검증") {
+        scenario("togglePrivateStatus 메서드를 사용할 경우 Post Entity의 privateStatus가 변경되어야 한다.") {
+            val beforePrivateStatus = postFixture.privateStatus
+
+            postFixture.togglePrivateStatus()
+
+            postFixture.privateStatus shouldBe !beforePrivateStatus
+        }
+    }
+    feature("Post Entity toggleBlindStatus 메서드 정상 동작 검증") {
+        scenario("toggleBlindStatus 메서드를 사용할 경우 Post Entity의 blindStatus가 변경되어야 한다.") {
+            val beforeBlindStatus = postFixture.blindStatus
+
+            postFixture.toggleBlindStatus()
+
+            postFixture.blindStatus shouldBe !beforeBlindStatus
+        }
+    }
+})


### PR DESCRIPTION
## Kotest test Spec 의사결정 내용

FeatureSpec을 사용하기로 결정함.

## 근거

BehaviorSpec은 Given/When/Then 구조를 지원하는 BDD용 스타일이다. **사용자의 행위를 작성**하고 결과를 검증하는데 초점이 맞춰져 있기 때문에 Post Entity 단위 테스트에는 맞지 않다고 판단하였다.

이와 달리 `FeatureSpec` 은 Feature/Scenario 구조를 지원하는 BDD용 스타일로 **시나리오의 행위자를 특정하기 어렵고, 기능에 대해서만 쓰여져있는 기획**에서 유용하게 쓸 수 있는 특징을 가진다.

따라서, Entity POJO 메서드 기능 테스트에는 적합하다고 판단하였다.

## 개발 작성 사항
1. PostEntityTest: Post Entity Test Code
2. PostEntity: togglePrivateStatus(), toggleBlindStatus() 기능 수정