### PR TITLE
ZRR-61 Bug: UserPrincipal 코드 수정으로 인한 Audit 버그 수정

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/global/config/MemberAwareAudit.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/config/MemberAwareAudit.kt
@@ -11,13 +11,12 @@ import java.util.*
 class MemberAwareAudit : AuditorAware<Long> {
 
     override fun getCurrentAuditor(): Optional<Long> {
-        // Spring Security를 통한 Auditor 매핑
-        val authentication: Authentication? = SecurityContextHolder.getContext().authentication
-        if (authentication == null || !authentication.isAuthenticated) {
+        val authentication: Authentication = SecurityContextHolder.getContext().authentication
+        if (authentication.authorities.any { it.authority == "OAUTH2_USER" }) {
             return Optional.empty()
         }
 
-        return Optional.of((authentication.principal as UserPrincipal).id)
+        return Optional.of((authentication.principal as UserPrincipal).memberId)
     }
 
 }


### PR DESCRIPTION
## Description the Bug
- 설명: UserPrincipal 코드 수정으로 인한 Audit 버그 발생
- 참조 해야하는 지라 티켓 : ZRR-61

## Bug 사진

## To Reproduce 
1. Compile시 UserPrincipal에 id 값이 없으므로 IDE에서 빨갛게 문제가 있다고 뜸.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/84d0eb22-7d32-4c53-976e-d2fdda7c4f02)


## 버그를 해결해야하는 방식

### 버그 발생 이유

기존의 audit 관련 클래스는 다음과 같다.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/84d0eb22-7d32-4c53-976e-d2fdda7c4f02)

기존 코드에서 UserPrincipal 의 id 값을 가져오지만 id가 다음과 같이 memberId로 변경됨에 따라 Audit가 제대로 동작하지 않는다.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/dea1a489-26c4-447e-b52b-3f8cec540b4e)


### 버그 해결

이를 다음과 같이 개선하였다.

OAuth2를 통해 로그인 한 사용자는 Authentication authority 에 OAUTH2_USER 를 값으로 가지므로 이 경우 실제 우리 서버에 가입된 사용자가 아니므로 null처리를 해주었다.

기존 코드에서 null 확인을 하는데 현재 서버에서 authentication이 null로서 들어올 수 있는 방법은 없다고 판단하여 optional 상태를 제거하였다.

![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/865248e2-4017-4c94-9833-9d19f8f05585)


### 테스트 - Auditor 동작 확인

1. 먼저 글을 생성한다.
당연히 글을 생성할 때 Auditor가 동작하여 CreatedBy와 ModifiedBy를 채워준다.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/5cc4ac5e-d9e2-419e-897a-d00ecd4c82e2)

2. 강제로 DB에서 ModifiedBy를 변경시킨다.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/7d9579de-423c-4b45-8e56-9671195aabff)

ModifiedBy가 2가 된 것을 확인.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/a450f899-c109-4a58-b9f4-5422bd58f018)

3. 이제 PostMan으로 id가 1인 계정으로 글을 수정했을 때 ModifiedBy가 1로 바뀌면 정상동작하는 것을 확인할 수 있을 것이다.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/0c7105e2-1507-4568-a3dc-16257f7dadf6)

Postman 전송 후 변경 확인!
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/1cee773a-036a-40b0-bc0c-72c7db7cb017)

4. 버그 해결 완료.

## ETC
- 고려해야할 점..

## Close Issue
Closes #38 
