### PR TITLE
ZRR-45 Bug: SocialMemberEntity Ban 관련 Property 추가에 따른 버그 발생

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
@@ -29,12 +29,10 @@ class SocialMemberEntity(
     var memberStatus: MemberStatus = MemberStatus.NORMAL,
 
     @Column(name = "banned_start_date", nullable = true)
-    var bannedStartDate: LocalDateTime?,
+    var bannedStartDate: LocalDateTime? = null,
 
     @Column(name = "banned_end_date", nullable = true)
-    var bannedEndDate: LocalDateTime?,
-
-
+    var bannedEndDate: LocalDateTime? = null,
     ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -50,7 +48,6 @@ class SocialMemberEntity(
         if (memberStatus != MemberStatus.BANNED) {
             return false
         }
-
         val now = LocalDateTime.now()
         return now.isAfter(bannedStartDate) && now.isBefore(bannedEndDate)
     }

--- a/src/test/kotlin/kr/zziririt/zziririt/ZziriritApplicationTests.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/ZziriritApplicationTests.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles("local")
 class ZziriritApplicationTests {
 
     @Test

--- a/src/test/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntityTest.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/domain/post/model/PostEntityTest.kt
@@ -2,6 +2,7 @@ package kr.zziririt.zziririt.domain.post.model
 
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.matchers.shouldBe
+import kr.zziririt.zziririt.domain.board.model.BoardEntity
 import kr.zziririt.zziririt.domain.member.model.MemberRole
 import kr.zziririt.zziririt.domain.member.model.OAuth2Provider
 import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity


### PR DESCRIPTION
# 버그 발생 이유
SocialMemberEntity 에 bannedStartDate, bannedEndDate 프로퍼티가 추가되면서 기본 생성자를 사용하던 곳에서 버그가 발생함.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/f0fc5297-5824-4efb-83fa-0a86c4bd4dbd)

기본 생성자 인자 값에 추가를 요구함.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/cbeb0077-ba5e-45c7-b3a3-87601372f932)

# 버그 개선

Entity 자체에 null 초기화를 진행해주었다.
![image](https://github.com/TeamBDMJ/Zziririt/assets/84966961/ecfb08cb-6395-4fb9-b8f9-6019dfa606e6)
