### PR TITLE
ZRR-42 Feat: Report API 개발

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/member/dto/request/AdjustRoleRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/member/dto/request/AdjustRoleRequest.kt
@@ -5,5 +5,5 @@ import kr.zziririt.zziririt.domain.member.model.MemberRole
 
 data class AdjustRoleRequest(
     @field: NotNull
-    val memberRole : MemberRole
+    val memberRole: MemberRole
 )

--- a/src/main/kotlin/kr/zziririt/zziririt/api/report/controller/ReportController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/report/controller/ReportController.kt
@@ -1,0 +1,53 @@
+package kr.zziririt.zziririt.api.report.controller
+
+import jakarta.validation.Valid
+import kr.zziririt.zziririt.api.report.dto.request.BanMemberRequest
+import kr.zziririt.zziririt.api.report.dto.request.MemberReportRequest
+import kr.zziririt.zziririt.api.report.service.ReportService
+import kr.zziririt.zziririt.global.responseEntity
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/cs/report")
+class ReportController(
+    private val reportService: ReportService
+) {
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping()
+    fun getReports(
+        @PageableDefault(
+            size = 30,
+            sort = ["created_at"]
+        ) pageable: Pageable
+    ) = responseEntity(HttpStatus.OK) { reportService.getReportListByPageable(pageable) }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{memberId}")
+    fun getPaginatedReportsByMemberId(
+        @PathVariable memberId: Long,
+        @PageableDefault(
+            size = 30,
+            sort = ["created_at"]
+        ) pageable: Pageable
+    ) = responseEntity(HttpStatus.OK) { reportService.getPaginatedReportListByMemberId(memberId, pageable) }
+
+    @PostMapping()
+    fun reportMember(
+        @Valid @RequestBody request: MemberReportRequest,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ) = responseEntity(HttpStatus.OK) { reportService.reportMember(request, userPrincipal) }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/ban")
+    fun banMember(
+        @Valid @RequestBody request: BanMemberRequest,
+    ) = responseEntity(HttpStatus.OK) { reportService.banMember(request) }
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/report/dto/request/BanMemberRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/report/dto/request/BanMemberRequest.kt
@@ -1,0 +1,25 @@
+package kr.zziririt.zziririt.api.report.dto.request
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.Size
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.domain.report.model.BannedHistoryEntity
+import java.time.LocalDateTime
+
+data class BanMemberRequest(
+    val memberId: Long,
+    @field: Min(1, message = "정지 기간은 최소 {min}시간부터 설정해야 합니다.")
+    @field: Max(100000, message = "정지 기간은 최대 {max}시간으로 설정해야 합니다.")
+    val period: Long,
+    @field: Size(min = 1, max = 500, message = "정지 사유는 {min}글자 이상, {max}글자 이하여야 합니다.")
+    val reason: String,
+) {
+    fun toEntity(member: SocialMemberEntity): BannedHistoryEntity = BannedHistoryEntity(
+        bannedReason = reason,
+        bannedStartDate = LocalDateTime.now(),
+        bannedPeriod = period,
+        bannedEndDate = LocalDateTime.now().plusHours(period),
+        bannedMemberId = member,
+    )
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/report/dto/request/MemberReportRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/report/dto/request/MemberReportRequest.kt
@@ -1,0 +1,35 @@
+package kr.zziririt.zziririt.api.report.dto.request
+
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import kr.zziririt.zziririt.domain.comment.model.CommentEntity
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.domain.post.model.PostEntity
+import kr.zziririt.zziririt.domain.report.model.ReportEntity
+
+data class MemberReportRequest(
+    @field: NotNull
+    val reportedMemberId: Long,
+    val reportedPostId: Long?,
+    val reportedCommentId: Long?,
+    @field: Size(min = 1, max = 300, message = "신고 사유는 {min}자 이상, {max}자 이하여야 합니다.")
+    val reportedReason: String
+) {
+
+    fun toEntity(
+        reporterMember: SocialMemberEntity,
+        reportedMember: SocialMemberEntity,
+        post: PostEntity?,
+        comment: CommentEntity?,
+    ) = ReportEntity (
+        reporterMember = reporterMember,
+        reportedMember = reportedMember,
+        reportedPostId = post,
+        reportedCommentId = comment,
+        reportedReason = reportedReason
+    )
+
+}
+
+
+

--- a/src/main/kotlin/kr/zziririt/zziririt/api/report/service/ReportService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/report/service/ReportService.kt
@@ -1,0 +1,68 @@
+package kr.zziririt.zziririt.api.report.service
+
+import jakarta.transaction.Transactional
+import kr.zziririt.zziririt.api.report.dto.request.BanMemberRequest
+import kr.zziririt.zziririt.api.report.dto.request.MemberReportRequest
+import kr.zziririt.zziririt.domain.comment.repository.CommentRepository
+import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
+import kr.zziririt.zziririt.domain.post.repository.PostRepository
+import kr.zziririt.zziririt.domain.report.repository.BannedHistoryRepository
+import kr.zziririt.zziririt.domain.report.repository.ReportRepository
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.ModelNotFoundException
+import kr.zziririt.zziririt.infra.querydsl.report.dto.ReportDto
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class ReportService(
+    private val reportRepository: ReportRepository,
+    private val memberRepository: SocialMemberRepository,
+    private val postRepository: PostRepository,
+    private val commentRepository: CommentRepository,
+    private val bannedHistoryRepository: BannedHistoryRepository
+) {
+
+    fun getReportListByPageable(pageable: Pageable): Page<ReportDto> {
+        return reportRepository.findByPageable(pageable)
+    }
+
+    fun getPaginatedReportListByMemberId(memberId: Long, pageable: Pageable): Page<ReportDto> {
+        return reportRepository.searchByReportedMemberId(memberId, pageable)
+    }
+
+    fun reportMember(request: MemberReportRequest, userPrincipal: UserPrincipal) {
+        val reporterMember = memberRepository.findByIdOrNull(userPrincipal.memberId) ?: throw ModelNotFoundException(
+            ErrorCode.MODEL_NOT_FOUND
+        )
+        val reportedMember = memberRepository.findByIdOrNull(request.reportedMemberId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+        val reportedPost = request.reportedPostId?.let { postRepository.findByIdOrNull(it) }
+        val reportedComment = request.reportedCommentId?.let { commentRepository.findByIdOrNull(it) }
+
+        val saveReport = request.toEntity(reporterMember, reportedMember, reportedPost, reportedComment)
+
+        reportRepository.save(saveReport)
+    }
+
+    @Transactional
+    fun banMember(request: BanMemberRequest) {
+        val banMember =
+            memberRepository.findByIdOrNull(request.memberId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+        val reports = reportRepository.findAllByReportedMemberId(banMember.id!!)
+        val bannedHistory = request.toEntity(banMember)
+
+        reports.forEach {
+            bannedHistory.reportedIdList.add(it.id)
+            it.reportProcessed()
+        }
+
+        banMember.toBanned()
+
+        bannedHistoryRepository.save(bannedHistory)
+    }
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
@@ -2,7 +2,6 @@ package kr.zziririt.zziririt.domain.member.model
 
 import jakarta.persistence.*
 import kr.zziririt.zziririt.global.entity.BaseTimeEntity
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "social_member")
@@ -28,29 +27,12 @@ class SocialMemberEntity(
     @Column(name = "member_status", nullable = false)
     var memberStatus: MemberStatus = MemberStatus.NORMAL,
 
-    @Column(name = "banned_start_date", nullable = true)
-    var bannedStartDate: LocalDateTime? = null,
 
-    @Column(name = "banned_end_date", nullable = true)
-    var bannedEndDate: LocalDateTime? = null,
     ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
-    fun banForPeriod(startTime: LocalDateTime, endTime: LocalDateTime) {
-        memberStatus = MemberStatus.BANNED
-        bannedStartDate = startTime
-        bannedEndDate = endTime
-    }
-
-    fun isBanned(): Boolean {
-        if (memberStatus != MemberStatus.BANNED) {
-            return false
-        }
-        val now = LocalDateTime.now()
-        return now.isAfter(bannedStartDate) && now.isBefore(bannedEndDate)
-    }
 
     fun toBoardManager() {
         this.memberRole = MemberRole.BOARD_MANAGER
@@ -58,6 +40,10 @@ class SocialMemberEntity(
 
     fun toViewer() {
         this.memberRole = MemberRole.VIEWER
+    }
+
+    fun toBanned() {
+        this.memberStatus = MemberStatus.BANNED
     }
 
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/report/model/BannedHistoryEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/report/model/BannedHistoryEntity.kt
@@ -1,0 +1,42 @@
+package kr.zziririt.zziririt.domain.report.model
+
+import jakarta.persistence.*
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.global.entity.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+import java.time.LocalDateTime
+
+
+@Entity
+@Table(name = "banned_history")
+@SQLDelete(sql = "UPDATE post SET is_deleted = true WHERE id = ?")
+@SQLRestriction(value = "is_deleted = false")
+class BannedHistoryEntity(
+
+    @Column(name = "banned_reason", nullable = false)
+    val bannedReason: String,
+
+    @Column(name = "banned_start_date", nullable = false)
+    var bannedStartDate: LocalDateTime,
+
+    @Column(name = "banned_period", nullable = false)
+    val bannedPeriod: Long,
+
+    @Column(name = "banned_end_date", nullable = false)
+    var bannedEndDate: LocalDateTime,
+
+    @ManyToOne
+    @JoinColumn(name = "banned_member_id")
+    val bannedMemberId: SocialMemberEntity,
+
+    @ElementCollection
+    @CollectionTable(name = "banned_reported_ids", joinColumns = [JoinColumn(name = "banned_history_id")])
+    @Column(name = "reported_id")
+    val reportedIdList: MutableList<Long> = mutableListOf()
+
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/report/model/ReportEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/report/model/ReportEntity.kt
@@ -1,0 +1,47 @@
+package kr.zziririt.zziririt.domain.report.model
+
+import jakarta.persistence.*
+import kr.zziririt.zziririt.domain.comment.model.CommentEntity
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.domain.post.model.PostEntity
+import kr.zziririt.zziririt.global.entity.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "report")
+@SQLDelete(sql = "UPDATE post SET is_deleted = true WHERE id = ?")
+@SQLRestriction(value = "is_deleted = false")
+class ReportEntity(
+
+    @ManyToOne
+    @JoinColumn(name = "reporter_user", nullable = false)
+    val reporterMember: SocialMemberEntity,
+
+    @ManyToOne
+    @JoinColumn(name = "reported_user", nullable = false)
+    val reportedMember: SocialMemberEntity,
+
+    @ManyToOne
+    @JoinColumn(name = "reported_post_id", nullable = true)
+    val reportedPostId: PostEntity? = null,
+
+    @ManyToOne
+    @JoinColumn(name = "reported_commnet_id", nullable = true)
+    val reportedCommentId: CommentEntity? = null,
+
+    @Column(name = "reported_reason", nullable = false)
+    val reportedReason: String,
+
+    @Column(name = "result", nullable = false)
+    var result: Boolean = false
+
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    fun reportProcessed() {
+        this.result = true
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/report/repository/BannedHistoryRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/report/repository/BannedHistoryRepository.kt
@@ -1,0 +1,7 @@
+package kr.zziririt.zziririt.domain.report.repository
+
+import kr.zziririt.zziririt.domain.report.model.BannedHistoryEntity
+import org.springframework.data.repository.CrudRepository
+
+interface BannedHistoryRepository : CrudRepository <BannedHistoryEntity, Long> {
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/report/repository/ReportRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/report/repository/ReportRepository.kt
@@ -1,0 +1,18 @@
+package kr.zziririt.zziririt.domain.report.repository
+
+import kr.zziririt.zziririt.domain.report.model.ReportEntity
+import kr.zziririt.zziririt.infra.querydsl.report.dto.ReportDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ReportRepository {
+    fun save(entity: ReportEntity): ReportEntity
+
+    fun findAll(): List<ReportEntity>
+
+    fun findAllByReportedMemberId(reportedMemberId: Long): List<ReportEntity>
+
+    fun findByPageable(pageable: Pageable): Page<ReportDto>
+
+    fun searchByReportedMemberId(memberId: Long, pageable: Pageable): Page<ReportDto>
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/report/repository/ReportRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/report/repository/ReportRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package kr.zziririt.zziririt.domain.report.repository
+
+import kr.zziririt.zziririt.domain.report.model.ReportEntity
+import kr.zziririt.zziririt.infra.jpa.report.ReportJpaRepository
+import kr.zziririt.zziririt.infra.querydsl.report.ReportQueryDslRepositoryImpl
+import kr.zziririt.zziririt.infra.querydsl.report.dto.ReportDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReportRepositoryImpl(
+    private val reportJpaRepository: ReportJpaRepository,
+    private val reportQueryDslRepositoryImpl: ReportQueryDslRepositoryImpl,
+) : ReportRepository {
+    override fun save(entity: ReportEntity): ReportEntity = reportJpaRepository.save(entity)
+
+    override fun findAll(): List<ReportEntity> = reportJpaRepository.findAll()
+    override fun findAllByReportedMemberId(reportedMemberId: Long): List<ReportEntity> =
+        reportJpaRepository.findAllByReportedMemberId(reportedMemberId)
+
+    override fun findByPageable(pageable: Pageable): Page<ReportDto> =
+        reportQueryDslRepositoryImpl.findByPageable(pageable)
+
+    override fun searchByReportedMemberId(memberId: Long, pageable: Pageable): Page<ReportDto> =
+        reportQueryDslRepositoryImpl.searchByReportedMemberId(memberId, pageable)
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/report/ReportJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/report/ReportJpaRepository.kt
@@ -1,0 +1,9 @@
+package kr.zziririt.zziririt.infra.jpa.report
+
+import kr.zziririt.zziririt.domain.report.model.ReportEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReportJpaRepository : JpaRepository<ReportEntity, Long> {
+
+    fun findAllByReportedMemberId(reportedMemberId: Long): List<ReportEntity>
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/oauth2/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/oauth2/CustomOAuth2UserService.kt
@@ -44,9 +44,7 @@ class CustomOAuth2UserService(
                     providerId = getAttribute("id", oAuth2User)!!,
                     provider = OAuth2Provider.NAVER,
                     memberRole = MemberRole.VIEWER,
-                    memberStatus = MemberStatus.NORMAL,
-                    bannedStartDate = null,
-                    bannedEndDate = null,
+                    memberStatus = MemberStatus.NORMAL
                 )
             )
         }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/report/ReportQueryDslRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/report/ReportQueryDslRepository.kt
@@ -1,0 +1,12 @@
+package kr.zziririt.zziririt.infra.querydsl.report
+
+import kr.zziririt.zziririt.infra.querydsl.report.dto.ReportDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface ReportQueryDslRepository {
+
+    fun findByPageable(pageable: Pageable): Page<ReportDto>
+    fun searchByReportedMemberId(memberId: Long, pageable: Pageable): Page<ReportDto>
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/report/ReportQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/report/ReportQueryDslRepositoryImpl.kt
@@ -1,0 +1,95 @@
+package kr.zziririt.zziririt.infra.querydsl.report
+
+import kr.zziririt.zziririt.domain.comment.model.QCommentEntity
+import kr.zziririt.zziririt.domain.member.model.QSocialMemberEntity
+import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
+import kr.zziririt.zziririt.domain.post.model.QPostEntity
+import kr.zziririt.zziririt.domain.report.model.QReportEntity
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.ModelNotFoundException
+import kr.zziririt.zziririt.infra.querydsl.QueryDslSupport
+import kr.zziririt.zziririt.infra.querydsl.report.dto.QReportDto
+import kr.zziririt.zziririt.infra.querydsl.report.dto.ReportDto
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReportQueryDslRepositoryImpl(
+    private val memberRepository: SocialMemberRepository
+) : QueryDslSupport(), ReportQueryDslRepository {
+    private val report = QReportEntity.reportEntity
+    private val member = QSocialMemberEntity.socialMemberEntity
+    private val post = QPostEntity.postEntity
+    private val comment = QCommentEntity.commentEntity
+    override fun findByPageable(pageable: Pageable): Page<ReportDto> {
+        val result = queryFactory
+            .select(
+                QReportDto(
+                    report.id,
+                    report.reporterMember.id,
+                    report.reportedMember.id,
+                    report.reportedPostId.id,
+                    report.reportedCommentId.id,
+                    report.reportedReason
+                )
+            )
+            .from(report)
+            .leftJoin(report.reportedMember, member)
+            .leftJoin(report.reportedPostId, post)
+            .leftJoin(report.reportedCommentId, comment)
+            .orderBy(report.createdAt.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val count = queryFactory
+            .select(report.count())
+            .from(report)
+            .leftJoin(report.reportedMember, member)
+            .leftJoin(report.reportedPostId, post)
+            .leftJoin(report.reportedCommentId, comment)
+            .fetchOne() ?: 0L
+
+        return PageImpl(result, pageable, count)
+    }
+
+    override fun searchByReportedMemberId(memberId: Long, pageable: Pageable): Page<ReportDto> {
+        val searchedMember =
+            memberRepository.findByIdOrNull(memberId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        val result = queryFactory
+            .select(
+                QReportDto(
+                    report.id,
+                    report.reporterMember.id,
+                    report.reportedMember.id,
+                    report.reportedPostId.id,
+                    report.reportedCommentId.id,
+                    report.reportedReason
+                )
+            )
+            .from(report)
+            .leftJoin(report.reportedMember, member)
+            .leftJoin(report.reportedPostId, post)
+            .leftJoin(report.reportedCommentId, comment)
+            .where(report.reportedMember.eq(searchedMember))
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val count = queryFactory
+            .select(report.count())
+            .from(report)
+            .leftJoin(report.reportedMember, member)
+            .leftJoin(report.reportedPostId, post)
+            .leftJoin(report.reportedCommentId, comment)
+            .where(report.reportedMember.eq(searchedMember))
+            .fetchOne() ?: 0L
+
+        return PageImpl(result, pageable, count)
+    }
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/report/dto/ReportDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/report/dto/ReportDto.kt
@@ -1,0 +1,12 @@
+package kr.zziririt.zziririt.infra.querydsl.report.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class ReportDto @QueryProjection constructor(
+    val id: Long,
+    val reporterMemberId: Long,
+    val reportedMemberId: Long,
+    val reportedPostId: Long?,
+    val reportedCommentId: Long?,
+    val reportedReason: String,
+)

--- a/src/test/kotlin/kr/zziririt/zziririt/domain/comment/model/CommentEntityTest.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/domain/comment/model/CommentEntityTest.kt
@@ -10,7 +10,7 @@ import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
 import kr.zziririt.zziririt.domain.post.model.PostEntity
 
 class CommentEntityTest: FeatureSpec({
-    val socialMember = SocialMemberEntity(email = "parkbro95@naver.com", nickname = "두주", provider = OAuth2Provider.NAVER, providerId = "dpUMgQQIWSw5QL3ExCfTOEPoimd239", memberRole = MemberRole.VIEWER, memberStatus = MemberStatus.NORMAL, bannedStartDate = null, bannedEndDate = null)
+    val socialMember = SocialMemberEntity(email = "parkbro95@naver.com", nickname = "두주", provider = OAuth2Provider.NAVER, providerId = "dpUMgQQIWSw5QL3ExCfTOEPoimd239", memberRole = MemberRole.VIEWER, memberStatus = MemberStatus.NORMAL)
     val board = BoardEntity(parent = null, socialMember = socialMember, boardName = "보드 이름")
     val post = PostEntity(board = board, socialMember = socialMember, title = "게시글 제목", content = "게시글 내용", privateStatus = false)
     val commentFixture = CommentEntity(post = post, socialMember = socialMember, content = "댓글 내용", privateStatus = false, zziritCount = 0L)


### PR DESCRIPTION
### 관련 이슈
---
#18 

### 상세 개발 내역
---

1. ReportController : Report API
- (어드민 전용)Report 전체 리스트 페이지네이션 적용
 - (어드민 전용) 특정 유저 정보를 입력하여 신고 내역 조회
 - (전체 권한) 유저 신고
 - (어드민 전용) 유저 차단
2. ReportService
 - (어드민 전용)Report 전체 리스트 페이지네이션 적용
 - (어드민 전용) 특정 유저 정보를 입력하여 신고 내역 조회
 - (전체 권한) 유저 신고
 - (어드민 전용) 유저 차단 ㄴ 유저 차단 시 member 상태값 변경 ㄴ 유저 차단 시 신고 내역들이 모두 처리 완료 상태로 변경 ㄴ 해당 유저에 대한 신고 내역은 collection 테이블에서 별도로 관리됨
 3. ReportRepository
 - 구현체 분리
 4. ReportQueryDslRepositoryImpl
 - 페이지네이션 구현
 5. ReportEntity : report raw data를 저장함
 6. CustomOAuth2UserService : banned 관련 내용을 BannedHistory에서 관리하므로 삭제함
 7. BanMemberRequest : Ban 처리 요청
  - validation 적용
 8. SocialMemberEntity
  - banned 관련 내용을 BannedHistory에서 관리하므로 삭제함