### PR TITLE
ZRR-69 Feat: Login History 개발

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/member/dto/response/GetMemberResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/member/dto/response/GetMemberResponse.kt
@@ -1,17 +1,25 @@
 package kr.zziririt.zziririt.api.member.dto.response
 
+import kr.zziririt.zziririt.domain.member.model.LoginHistoryEntity
 import kr.zziririt.zziririt.domain.member.model.MemberStatus
 import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import java.time.LocalDateTime
 
 data class GetMemberResponse(
     val nickname: String,
-    val memberStatus: MemberStatus
-){
-    companion object{
-        fun from(socialMemberEntity: SocialMemberEntity): GetMemberResponse {
+    val memberStatus: MemberStatus,
+    val lastLogin: LocalDateTime,
+) {
+    companion object {
+        fun from(
+            socialMemberEntity: SocialMemberEntity,
+            loginHistoryEntity: LoginHistoryEntity
+
+        ): GetMemberResponse {
             return GetMemberResponse(
                 nickname = socialMemberEntity.nickname,
-                memberStatus = socialMemberEntity.memberStatus
+                memberStatus = socialMemberEntity.memberStatus,
+                lastLogin = loginHistoryEntity.createdAt
             )
         }
     }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/LoginHistoryEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/LoginHistoryEntity.kt
@@ -1,0 +1,33 @@
+package kr.zziririt.zziririt.domain.member.model
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "login_history")
+class LoginHistoryEntity(
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    val memberId: SocialMemberEntity,
+
+    @Column(name = "ip")
+    val ip: String,
+
+    @Column(name = "user_environment")
+    val userEnvironment: String,
+
+    ) {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    @CreatedDate
+    @Column(name = "created_at")
+    lateinit var createdAt: LocalDateTime
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/LoginHistoryRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/LoginHistoryRepository.kt
@@ -1,0 +1,12 @@
+package kr.zziririt.zziririt.domain.member.repository
+
+import kr.zziririt.zziririt.domain.member.model.LoginHistoryEntity
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+
+interface LoginHistoryRepository {
+
+    fun findTopByMemberIdOrderByCreatedAtDesc(memberId: SocialMemberEntity): LoginHistoryEntity
+
+    fun save(entity: LoginHistoryEntity): LoginHistoryEntity
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/LoginHistoryRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/LoginHistoryRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package kr.zziririt.zziririt.domain.member.repository
+
+import kr.zziririt.zziririt.domain.member.model.LoginHistoryEntity
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.infra.jpa.member.LoginHistoryJpaRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class LoginHistoryRepositoryImpl(
+    private val loginHistoryJpaRepository: LoginHistoryJpaRepository
+) : LoginHistoryRepository {
+
+    fun findByIdOrNull(id: Long): LoginHistoryEntity? = loginHistoryJpaRepository.findByIdOrNull(id)
+
+    override fun save(entity: LoginHistoryEntity) = loginHistoryJpaRepository.save(entity)
+
+    override fun findTopByMemberIdOrderByCreatedAtDesc(memberId: SocialMemberEntity): LoginHistoryEntity =
+        loginHistoryJpaRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
+
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/member/LoginHistoryJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/member/LoginHistoryJpaRepository.kt
@@ -1,0 +1,11 @@
+package kr.zziririt.zziririt.infra.jpa.member
+
+import kr.zziririt.zziririt.domain.member.model.LoginHistoryEntity
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LoginHistoryJpaRepository : JpaRepository<LoginHistoryEntity, Long> {
+
+    fun findTopByMemberIdOrderByCreatedAtDesc(memberId: SocialMemberEntity): LoginHistoryEntity
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/oauth2/OAuthLoginController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/oauth2/OAuthLoginController.kt
@@ -1,5 +1,6 @@
 package kr.zziririt.zziririt.infra.oauth2
 
+import jakarta.servlet.http.HttpServletRequest
 import kr.zziririt.zziririt.infra.security.jwt.JwtDto
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -14,7 +15,10 @@ class OAuthLoginController(
     private val authService: CustomOAuth2UserService
 ) {
     @GetMapping("/login")
-    fun login(@AuthenticationPrincipal oAuth2User: OAuth2User): ResponseEntity<JwtDto> {
-        return ResponseEntity.ok(authService.login(oAuth2User))
+    fun login(
+        @AuthenticationPrincipal oAuth2User: OAuth2User,
+        request: HttpServletRequest
+    ): ResponseEntity<JwtDto> {
+        return ResponseEntity.ok(authService.login(oAuth2User, request))
     }
 }


### PR DESCRIPTION
관련 이슈
https://github.com/TeamBDMJ/Zziririt/issues/48
---

상세 개발 내역
1. CustomOAuth2UserService
- login 시 loginHistory에 접속 정보가 저장됨
- 접속정보: ip, 사용환경, memberId, 현재시각(로컬기준)

2. GetMemberResponse
- "내 정보 보기" 기능에서, 최근 접속일자도 확인할 수 있도록 추가

3. LoginHistoryJpaRepository
- 최근 접속일자를 확인하기 위해 MemberId에서, 가장 최신의 CreatedAt을 가져오는 JPA method 생성

4. LoginHistoryJpaRepository
- Repository 분리

5. OAuthLoginController
- ip, 사용환경 수집을 위한 request 생성