### PR TITLE
ZRR-76 Feat: 휴면 유저 전환 Scheduler

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/member/service/MemberService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/member/service/MemberService.kt
@@ -11,7 +11,7 @@ import kr.zziririt.zziririt.global.exception.ErrorCode
 import kr.zziririt.zziririt.global.exception.ModelNotFoundException
 import kr.zziririt.zziririt.global.exception.RestApiException
 import kr.zziririt.zziririt.infra.security.UserPrincipal
-import org.springframework.data.repository.findByIdOrNull
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
 @Service
@@ -63,6 +63,17 @@ class MemberService(
         }
 
         boardManagerCheck.toViewer()
+    }
+
+
+    @Scheduled(cron = "0 0 3 1/1 * ?")
+    @Transactional
+    fun updateMemberStatusToSleeper() {
+        val sleeperCandidates = memberRepository.findSleeperCandidatesMemberId()
+
+        if(sleeperCandidates.isNotEmpty()) {
+            memberRepository.bulkUpdateMemberStatusToSleeper(sleeperCandidates)
+        }
     }
 
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/SocialMemberRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/SocialMemberRepository.kt
@@ -1,12 +1,17 @@
 package kr.zziririt.zziririt.domain.member.repository
 
 import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
-import org.springframework.data.repository.CrudRepository
-import org.springframework.stereotype.Repository
 
-@Repository
-interface SocialMemberRepository : CrudRepository<SocialMemberEntity, Long> {
+
+interface SocialMemberRepository {
 
     fun findByEmail(email: String): SocialMemberEntity?
 
+    fun findByIdOrNull(id: Long): SocialMemberEntity?
+
+    fun findSleeperCandidatesMemberId() : List<Long>
+
+    fun save(entity : SocialMemberEntity) : SocialMemberEntity
+
+    fun bulkUpdateMemberStatusToSleeper(memberIdList: List<Long>)
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/SocialMemberRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/SocialMemberRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package kr.zziririt.zziririt.domain.member.repository
+
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import kr.zziririt.zziririt.infra.jpa.member.SocialMemberJpaRepository
+import kr.zziririt.zziririt.infra.querydsl.member.SocialMemberQueryDslRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class SocialMemberRepositoryImpl(
+    private val memberJpaRepository : SocialMemberJpaRepository,
+    private val memberQueryDslRepository: SocialMemberQueryDslRepository
+) : SocialMemberRepository{
+    override fun findByEmail(email: String): SocialMemberEntity? = memberJpaRepository.findByEmail(email)
+
+    override fun findByIdOrNull(id: Long): SocialMemberEntity? = memberJpaRepository.findByIdOrNull(id)
+
+    override fun findSleeperCandidatesMemberId() : List<Long> = memberQueryDslRepository.findSleeperCandidatesMemberId()
+    override fun save(entity: SocialMemberEntity): SocialMemberEntity = memberJpaRepository.save(entity)
+    override fun bulkUpdateMemberStatusToSleeper(memberIdList: List<Long>) = memberQueryDslRepository.bulkUpdateMemberStatusToSleeper(memberIdList)
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/member/SocialMemberJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/member/SocialMemberJpaRepository.kt
@@ -1,0 +1,10 @@
+package kr.zziririt.zziririt.infra.jpa.member
+
+import kr.zziririt.zziririt.domain.member.model.SocialMemberEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SocialMemberJpaRepository : JpaRepository<SocialMemberEntity, Long> {
+
+    fun findByEmail(email: String) : SocialMemberEntity?
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/SocialMemberQueryDslRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/SocialMemberQueryDslRepository.kt
@@ -1,0 +1,9 @@
+package kr.zziririt.zziririt.infra.querydsl.member
+
+
+interface SocialMemberQueryDslRepository {
+
+    fun findSleeperCandidatesMemberId() : List<Long>
+
+    fun bulkUpdateMemberStatusToSleeper(memberIdList: List<Long>)
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/SocialMemberQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/SocialMemberQueryDslRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package kr.zziririt.zziririt.infra.querydsl.member
+
+import kr.zziririt.zziririt.domain.member.model.MemberStatus
+import kr.zziririt.zziririt.domain.member.model.QLoginHistoryEntity
+import kr.zziririt.zziririt.domain.member.model.QSocialMemberEntity
+import kr.zziririt.zziririt.infra.querydsl.QueryDslSupport
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class SocialMemberQueryDslRepositoryImpl : SocialMemberQueryDslRepository, QueryDslSupport() {
+
+    private val member = QSocialMemberEntity.socialMemberEntity
+    private val loginHistory = QLoginHistoryEntity.loginHistoryEntity
+
+    override fun findSleeperCandidatesMemberId() : List<Long> {
+        val baseSleeperTime = LocalDateTime.now().minusYears(1)
+
+        return queryFactory
+            .select(member.id)
+            .from(member)
+            .leftJoin(loginHistory)
+            .on(member.id.eq(loginHistory.memberId.id), loginHistory.createdAt.goe(baseSleeperTime))
+            .where(loginHistory.memberId.isNull)
+            .fetch()
+    }
+
+    override fun bulkUpdateMemberStatusToSleeper(memberIdList: List<Long>) {
+         queryFactory
+             .update(member)
+             .set(member.memberStatus, MemberStatus.SLEEPER)
+             .where(member.id.`in`(memberIdList))
+             .execute()
+    }
+
+}


### PR DESCRIPTION
관련 이슈
***
#58 

개발 내용
###
1.MemberService
- 휴면 유저로 전환하는 Scheduler 설정
- 매일 오전 03시 실행됨

2. SocialMemberRepository 분리

3. QueryDsl 적용
- loginHistory 기준 1년간 접속 기록이 없는 memberId List 추출
- memberIdList를 SLEEPER 상태로 변경
- Bulk Update 적용