### PR TITLE
ZRR-82 Feature: Icon, Icon Shop 개발

### DIFF
--- a/src/main/kotlin/kr/zziririt/zziririt/api/icon/controller/IconController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/icon/controller/IconController.kt
@@ -1,0 +1,40 @@
+package kr.zziririt.zziririt.api.icon.controller
+
+import kr.zziririt.zziririt.api.icon.dto.request.AddIconRequest
+import kr.zziririt.zziririt.api.icon.service.IconService
+import kr.zziririt.zziririt.global.responseEntity
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+@RestController
+@RequestMapping("/api/v1/icons")
+class IconController(
+    private val iconService: IconService
+) {
+    @PostMapping("/add")
+    fun addIcon(
+        @RequestPart request: AddIconRequest,
+        @RequestPart file: List<MultipartFile>,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ) = responseEntity(HttpStatus.OK) { iconService.addIcon(request, file, userPrincipal) }
+
+    @DeleteMapping("/{iconId}")
+    fun deleteIcon(
+        @PathVariable iconId: Long,
+    ) = responseEntity(HttpStatus.OK) { iconService.deleteIcon(iconId) }
+
+    @GetMapping("/myicon")
+    fun getMyIcons(
+        @PageableDefault(
+            size = 10,
+            sort = ["createdAt"]
+        ) pageable: Pageable,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ) = responseEntity(HttpStatus.OK) { iconService.getMyIcons(pageable, userPrincipal) }
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/icon/dto/request/AddIconRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/icon/dto/request/AddIconRequest.kt
@@ -1,0 +1,16 @@
+package kr.zziririt.zziririt.api.icon.dto.request
+
+import kr.zziririt.zziririt.domain.icon.model.IconEntity
+
+data class AddIconRequest(
+    val iconName: String,
+    val iconApplicationUrl: String,
+    val iconMaker: String,
+) {
+    fun toEntity(iconUrl: String): IconEntity = IconEntity(
+        iconName = iconName,
+        iconUrl = iconUrl,
+        iconApplicationUrl = iconApplicationUrl,
+        iconMaker = iconMaker
+    )
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/icon/service/IconService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/icon/service/IconService.kt
@@ -1,0 +1,51 @@
+package kr.zziririt.zziririt.api.icon.service
+
+import jakarta.transaction.Transactional
+import kr.zziririt.zziririt.api.icon.dto.request.AddIconRequest
+import kr.zziririt.zziririt.domain.icon.repository.IconRepository
+import kr.zziririt.zziririt.domain.member.repository.MemberIconRepository
+import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.ModelNotFoundException
+import kr.zziririt.zziririt.infra.aws.S3Service
+import kr.zziririt.zziririt.infra.querydsl.member.dto.GetMyIconsDto
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class IconService (
+    private val memberRepository: SocialMemberRepository,
+    private val iconRepository: IconRepository,
+    private val s3Service: S3Service,
+    private val memberIconRepository: MemberIconRepository,
+) {
+
+    @Transactional
+    fun addIcon(request: AddIconRequest, file: List<MultipartFile>, userPrincipal: UserPrincipal){
+        memberRepository.findByIdOrNull(userPrincipal.memberId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+        val iconUrl = s3Service.uploadFiles("icon",file)
+
+        iconUrl.forEach {
+            val newIcon = request.toEntity(it)
+            iconRepository.save(newIcon)
+        }
+    }
+
+    fun deleteIcon(iconId: Long) {
+        val iconCheck = iconRepository.findByIdOrNull(iconId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        iconRepository.delete(iconCheck)
+    }
+
+    fun getMyIcons(pageable: Pageable, userPrincipal: UserPrincipal) : PageImpl<GetMyIconsDto> {
+        memberRepository.findByIdOrNull(userPrincipal.memberId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        return memberIconRepository.getMyIcons(pageable)
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/controller/IconProductController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/controller/IconProductController.kt
@@ -32,9 +32,9 @@ class IconProductController(
     ) = responseEntity(HttpStatus.OK) { iconProductService.changeStatus(iconProductId, request) }
 
     @DeleteMapping("/{iconProductId}")
-    fun iconProductDelete(
+    fun deleteIconProduct(
         @PathVariable iconProductId: Long,
-    ) = responseEntity(HttpStatus.OK) { iconProductService.iconProductDelete(iconProductId) }
+    ) = responseEntity(HttpStatus.OK) { iconProductService.deleteIconProduct(iconProductId) }
 
     @GetMapping("/{iconProductId}")
     fun getIconProduct(

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/controller/IconProductController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/controller/IconProductController.kt
@@ -1,0 +1,58 @@
+package kr.zziririt.zziririt.api.iconproduct.controller
+
+import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
+import kr.zziririt.zziririt.api.iconproduct.dto.request.BuyIconProductRequest
+import kr.zziririt.zziririt.api.iconproduct.dto.request.ChangeSaleStatusRequest
+import kr.zziririt.zziririt.api.iconproduct.dto.request.IconProductRequest
+import kr.zziririt.zziririt.api.iconproduct.service.IconProductService
+import kr.zziririt.zziririt.global.responseEntity
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/v1/iconproduct")
+class IconProductController(
+    private val iconProductService: IconProductService,
+) {
+
+    @PostMapping("/registration")
+    fun registerIconProduct(
+        @RequestBody request: IconProductRequest
+    ) = responseEntity(HttpStatus.OK) { iconProductService.registerIconProduct(request) }
+
+
+    @PutMapping("/{iconProductId}")
+    fun changeSaleStatus(
+        @PathVariable iconProductId: Long,
+        @RequestBody request: ChangeSaleStatusRequest
+    ) = responseEntity(HttpStatus.OK) { iconProductService.changeStatus(iconProductId, request) }
+
+    @DeleteMapping("/{iconProductId}")
+    fun iconProductDelete(
+        @PathVariable iconProductId: Long,
+    ) = responseEntity(HttpStatus.OK) { iconProductService.iconProductDelete(iconProductId) }
+
+    @GetMapping("/{iconProductId}")
+    fun getIconProduct(
+        @PathVariable iconProductId: Long
+    ) = responseEntity(HttpStatus.OK) { iconProductService.getIconProduct(iconProductId) }
+
+    @GetMapping()
+    fun getIconProducts(
+        condition: IconSearchCondition,
+        @PageableDefault(
+            size = 30,
+            sort = ["createdAt"]
+        ) pageable: Pageable
+    ) = responseEntity(HttpStatus.OK) { iconProductService.getIconProducts(condition, pageable)}
+
+    @PostMapping("/purchase")
+    fun buyIconProduct(
+        @RequestBody request: BuyIconProductRequest,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal
+    ) = responseEntity(HttpStatus.OK) { iconProductService.buyIconProduct(request, userPrincipal)}
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/IconSearchCondition.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/IconSearchCondition.kt
@@ -1,0 +1,13 @@
+package kr.zziririt.zziririt.api.iconproduct.dto
+
+import kr.zziririt.zziririt.api.iconproduct.dto.valid.ValidSaleStatusType
+import org.springframework.validation.annotation.Validated
+
+@Validated
+data class IconSearchCondition(
+    @field:ValidSaleStatusType
+    val searchType: String?,
+    val searchTerm: String?,
+    val page: String = "1",
+    val size: String = "30",
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/request/BuyIconProductRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/request/BuyIconProductRequest.kt
@@ -1,0 +1,5 @@
+package kr.zziririt.zziririt.api.iconproduct.dto.request
+
+data class BuyIconProductRequest(
+    val iconProductId: Long
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/request/ChangeSaleStatusRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/request/ChangeSaleStatusRequest.kt
@@ -1,0 +1,7 @@
+package kr.zziririt.zziririt.api.iconproduct.dto.request
+
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+
+data class ChangeSaleStatusRequest(
+    val saleStatus: SaleStatus,
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/request/IconProductRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/request/IconProductRequest.kt
@@ -1,0 +1,19 @@
+package kr.zziririt.zziririt.api.iconproduct.dto.request
+
+import kr.zziririt.zziririt.domain.icon.model.IconEntity
+import kr.zziririt.zziririt.domain.iconproduct.model.IconProductEntity
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+
+data class IconProductRequest(
+    val iconId: Long,
+    val price: Long,
+    val iconQuantity: Int,
+    val saleStatus: SaleStatus,
+) {
+    fun toEntity(icon: IconEntity): IconProductEntity = IconProductEntity(
+        icon = icon,
+        price = price,
+        iconQuantity = iconQuantity,
+        saleStatus = saleStatus,
+    )
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/response/IconProductResponse.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/response/IconProductResponse.kt
@@ -1,0 +1,22 @@
+package kr.zziririt.zziririt.api.iconproduct.dto.response
+
+import kr.zziririt.zziririt.domain.iconproduct.model.IconProductEntity
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+
+data class IconProductResponse(
+    val iconProductId: Long,
+    val price: Long,
+    val iconQuantity: Int,
+    val saleStatus: SaleStatus,
+    val iconId: Long,
+) {
+    companion object {
+        fun from(iconProductEntity: IconProductEntity): IconProductResponse = IconProductResponse(
+            iconProductId = iconProductEntity.id,
+            price = iconProductEntity.price,
+            iconQuantity = iconProductEntity.iconQuantity,
+            saleStatus = iconProductEntity.saleStatus,
+            iconId = iconProductEntity.icon.id
+        )
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/valid/IconSearchTypeValidation.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/dto/valid/IconSearchTypeValidation.kt
@@ -1,0 +1,24 @@
+package kr.zziririt.zziririt.api.iconproduct.dto.valid
+
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [IconSearchTypeValidator::class])
+annotation class ValidSaleStatusType(
+    val message: String = "올바르지 않은 SaleStatus 값입니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Any>> = []
+)
+
+class IconSearchTypeValidator : ConstraintValidator<ValidSaleStatusType, String> {
+    override fun initialize(constraintAnnotation: ValidSaleStatusType) {}
+
+    override fun isValid(value: String?, context: ConstraintValidatorContext): Boolean {
+        return value == null || SaleStatus.entries.any { it.name == value.uppercase() }
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/service/IconProductService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/service/IconProductService.kt
@@ -51,7 +51,7 @@ class IconProductService(
     }
 
     @Transactional
-    fun iconProductDelete(iconProductId: Long) {
+    fun deleteIconProduct(iconProductId: Long) {
         val iconProductCheck =
             iconProductRepository.findByIdOrNull(iconProductId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
 

--- a/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/service/IconProductService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/iconproduct/service/IconProductService.kt
@@ -1,0 +1,102 @@
+package kr.zziririt.zziririt.api.iconproduct.service
+
+import jakarta.transaction.Transactional
+import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
+import kr.zziririt.zziririt.api.iconproduct.dto.request.BuyIconProductRequest
+import kr.zziririt.zziririt.api.iconproduct.dto.request.ChangeSaleStatusRequest
+import kr.zziririt.zziririt.api.iconproduct.dto.request.IconProductRequest
+import kr.zziririt.zziririt.api.iconproduct.dto.response.IconProductResponse
+import kr.zziririt.zziririt.domain.icon.repository.IconRepository
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+import kr.zziririt.zziririt.domain.iconproduct.repository.IconProductRepository
+import kr.zziririt.zziririt.domain.member.model.MemberIconEntity
+import kr.zziririt.zziririt.domain.member.repository.MemberIconRepository
+import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.ModelNotFoundException
+import kr.zziririt.zziririt.global.exception.RestApiException
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.IconProductRowDto
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class IconProductService(
+    private val iconProductRepository: IconProductRepository,
+    private val iconRepository: IconRepository,
+    private val memberRepository: SocialMemberRepository,
+    private val memberIconRepository: MemberIconRepository,
+) {
+    fun registerIconProduct(request: IconProductRequest) {
+        val iconCheck =
+            iconRepository.findByIdOrNull(request.iconId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        check(iconProductRepository.findByIdOrNull(request.iconId) == null) {
+            throw RestApiException(ErrorCode.DUPLICATE_ICON_ID)
+        }
+
+        val iconProduct = request.toEntity(iconCheck)
+
+        iconProductRepository.save(iconProduct)
+    }
+
+    @Transactional
+    fun changeStatus(iconProductId: Long, request: ChangeSaleStatusRequest) {
+        val iconProductCheck =
+            iconProductRepository.findByIdOrNull(iconProductId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        iconProductCheck.changeStatus(request.saleStatus)
+    }
+
+    @Transactional
+    fun iconProductDelete(iconProductId: Long) {
+        val iconProductCheck =
+            iconProductRepository.findByIdOrNull(iconProductId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        iconProductRepository.delete(iconProductCheck)
+    }
+
+    @Transactional
+    fun getIconProduct(iconProductId: Long): IconProductResponse {
+        val iconProductCheck =
+            iconProductRepository.findByIdOrNull(iconProductId) ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        return IconProductResponse.from(iconProductCheck)
+    }
+
+    fun getIconProducts(condition: IconSearchCondition, pageable: Pageable): PageImpl<IconProductRowDto> {
+
+        return iconProductRepository.searchBy(
+            condition,
+            pageable
+        )
+    }
+
+    @Transactional
+    fun buyIconProduct(request: BuyIconProductRequest, userPrincipal: UserPrincipal) {
+        val memberCheck = memberRepository.findByIdOrNull(userPrincipal.memberId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+        val iconProductCheck = iconProductRepository.findByIdOrNull(request.iconProductId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+        val memberIconCheck = memberIconRepository.findByIdOrNull(memberCheck.id!!)
+
+        check(memberCheck.point > iconProductCheck.price) {
+            throw RestApiException(ErrorCode.NOT_ENOUGH_POINT)
+        }
+        check(iconProductCheck.iconQuantity > 0) {
+            throw RestApiException(ErrorCode.NOT_ENOUGH_ICONQUANTITY)
+        }
+        check(iconProductCheck.saleStatus == SaleStatus.SALE) {
+            throw RestApiException(ErrorCode.NOT_FOR_SALE_STATUS)
+        }
+        check(memberIconCheck?.icon?.id != iconProductCheck.icon.id) {
+            throw RestApiException(ErrorCode.ALREADY_HAVE_ICON)
+        }
+
+        iconProductCheck.reduceIconQuantityAndChangeSaleStatus()
+        memberCheck.pointMinus(iconProductCheck.price)
+        memberIconRepository.save(MemberIconEntity(memberCheck, iconProductCheck.icon))
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/api/member/controller/MemberController.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/member/controller/MemberController.kt
@@ -2,6 +2,7 @@ package kr.zziririt.zziririt.api.member.controller
 
 import jakarta.validation.Valid
 import kr.zziririt.zziririt.api.member.dto.request.AdjustRoleRequest
+import kr.zziririt.zziririt.api.member.dto.request.SelectMyIconRequest
 import kr.zziririt.zziririt.api.member.dto.request.SetBoardManagerRequest
 import kr.zziririt.zziririt.api.member.service.MemberService
 import kr.zziririt.zziririt.global.responseEntity
@@ -49,4 +50,11 @@ class MemberController(
     fun getSubscribeBoards(
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ) = responseEntity(HttpStatus.OK) { memberService.getSubscribeByMember(userPrincipal) }
+
+    @PutMapping("/iconselect")
+    fun selectDefaultIcon(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @RequestBody request: SelectMyIconRequest,
+    ) = responseEntity(HttpStatus.OK) { memberService.selectMyIcon(userPrincipal, request)}
+
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/api/member/dto/request/SelectMyIconRequest.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/member/dto/request/SelectMyIconRequest.kt
@@ -1,0 +1,5 @@
+package kr.zziririt.zziririt.api.member.dto.request
+
+data class SelectMyIconRequest(
+    val iconId: Long
+)

--- a/src/main/kotlin/kr/zziririt/zziririt/api/member/service/MemberService.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/api/member/service/MemberService.kt
@@ -2,10 +2,12 @@ package kr.zziririt.zziririt.api.member.service
 
 import jakarta.transaction.Transactional
 import kr.zziririt.zziririt.api.member.dto.request.AdjustRoleRequest
+import kr.zziririt.zziririt.api.member.dto.request.SelectMyIconRequest
 import kr.zziririt.zziririt.api.member.dto.request.SetBoardManagerRequest
 import kr.zziririt.zziririt.api.member.dto.response.GetMemberResponse
 import kr.zziririt.zziririt.domain.member.model.MemberRole
 import kr.zziririt.zziririt.domain.member.repository.LoginHistoryRepository
+import kr.zziririt.zziririt.domain.member.repository.MemberIconRepository
 import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
 import kr.zziririt.zziririt.global.exception.ErrorCode
 import kr.zziririt.zziririt.global.exception.ModelNotFoundException
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service
 @Service
 class MemberService(
     private val memberRepository: SocialMemberRepository,
+    private val memberIconRepository: MemberIconRepository,
     private val loginHistoryRepository: LoginHistoryRepository
 ) {
 
@@ -83,4 +86,17 @@ class MemberService(
         return memberCheck.subscribeBoardsList.map { it }
     }
 
+    @Transactional
+    fun selectMyIcon(userPrincipal: UserPrincipal, request: SelectMyIconRequest) {
+        val memberCheck = memberRepository.findByIdOrNull(userPrincipal.memberId)
+            ?: throw ModelNotFoundException(ErrorCode.MODEL_NOT_FOUND)
+
+        val iconCheck = memberIconRepository.existsByMemberIdAndIconId(memberCheck.id!!, request.iconId)
+
+        check(iconCheck) {
+            throw RestApiException(ErrorCode.NOT_HAVE_ICON)
+        }
+
+        memberCheck.changeDefaultIcon(request.iconId)
+    }
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/icon/model/IconEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/icon/model/IconEntity.kt
@@ -1,0 +1,30 @@
+package kr.zziririt.zziririt.domain.icon.model
+
+import jakarta.persistence.*
+import kr.zziririt.zziririt.global.entity.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "icon")
+@SQLDelete(sql = "UPDATE icon SET is_deleted = true WHERE id = ?")
+@SQLRestriction(value = "is_deleted = false")
+class IconEntity(
+
+    @Column(name = "icon_name")
+    val iconName: String,
+
+    @Column(name = "icon_url")
+    val iconUrl: String,
+
+    @Column(name = "icon_request_url")
+    val iconApplicationUrl: String,
+
+    @Column(name = "icon_maker")
+    val iconMaker: String,
+
+    ) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/icon/repository/IconRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/icon/repository/IconRepository.kt
@@ -1,0 +1,6 @@
+package kr.zziririt.zziririt.domain.icon.repository
+
+import kr.zziririt.zziririt.domain.icon.model.IconEntity
+import org.springframework.data.repository.CrudRepository
+
+interface IconRepository : CrudRepository<IconEntity, Long> {}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/model/IconProductEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/model/IconProductEntity.kt
@@ -1,0 +1,53 @@
+package kr.zziririt.zziririt.domain.iconproduct.model
+
+import jakarta.persistence.*
+import kr.zziririt.zziririt.domain.icon.model.IconEntity
+import kr.zziririt.zziririt.global.entity.BaseEntity
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.RestApiException
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "icon_shop")
+@SQLDelete(sql = "UPDATE icon_shop SET is_deleted = true WHERE id = ?")
+@SQLRestriction(value = "is_deleted = false")
+class IconProductEntity(
+
+    @ManyToOne
+    @JoinColumn(name = "icon_id")
+    val icon: IconEntity,
+
+    @Column(name = "price")
+    val price: Long,
+
+    @Column(name = "icon_quantity")
+    var iconQuantity: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sale_status")
+    var saleStatus: SaleStatus
+
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    init {
+        if (this.iconQuantity <= 0) {
+            throw RestApiException(ErrorCode.ITEM_POLICY_VIOLATION)
+        }
+    }
+
+    fun changeStatus(status: SaleStatus) {
+        this.saleStatus = status
+    }
+
+    fun reduceIconQuantityAndChangeSaleStatus() {
+        this.iconQuantity--
+
+        if (this.iconQuantity == 0) {
+            this.saleStatus = SaleStatus.SOLDOUT
+        }
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/model/SaleStatus.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/model/SaleStatus.kt
@@ -1,0 +1,5 @@
+package kr.zziririt.zziririt.domain.iconproduct.model
+
+enum class SaleStatus {
+    PREPARE, SALE, SOLDOUT
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/repository/IconProductRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/repository/IconProductRepository.kt
@@ -1,0 +1,17 @@
+package kr.zziririt.zziririt.domain.iconproduct.repository
+
+import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
+import kr.zziririt.zziririt.domain.iconproduct.model.IconProductEntity
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.IconProductRowDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+interface IconProductRepository {
+    fun searchBy(condition: IconSearchCondition, pageable: Pageable): PageImpl<IconProductRowDto>
+
+    fun findByIdOrNull(id: Long): IconProductEntity?
+
+    fun save(entity: IconProductEntity): IconProductEntity
+
+    fun delete(entity: IconProductEntity)
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/repository/IconProductRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/iconproduct/repository/IconProductRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package kr.zziririt.zziririt.domain.iconproduct.repository
+
+import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
+import kr.zziririt.zziririt.domain.iconproduct.model.IconProductEntity
+import kr.zziririt.zziririt.infra.jpa.iconproduct.IconProductJpaRepository
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.IconProductQueryDslRepository
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.IconProductRowDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class IconProductRepositoryImpl(
+    private val iconProductQueryDslRepository: IconProductQueryDslRepository,
+    private val iconProductJpaRepository: IconProductJpaRepository,
+) : IconProductRepository {
+    override fun searchBy(condition: IconSearchCondition, pageable: Pageable): PageImpl<IconProductRowDto> =
+        iconProductQueryDslRepository.searchBy(condition, pageable)
+
+    override fun findByIdOrNull(id: Long): IconProductEntity? = iconProductJpaRepository.findByIdOrNull(id)
+
+    override fun save(entity: IconProductEntity): IconProductEntity = iconProductJpaRepository.save(entity)
+
+    override fun delete(entity: IconProductEntity) = iconProductJpaRepository.delete(entity)
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/MemberIconEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/MemberIconEntity.kt
@@ -1,0 +1,27 @@
+package kr.zziririt.zziririt.domain.member.model
+
+import jakarta.persistence.*
+import kr.zziririt.zziririt.domain.icon.model.IconEntity
+import kr.zziririt.zziririt.global.entity.BaseEntity
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Table(name = "member_icon")
+@SQLDelete(sql = "UPDATE member_icon SET is_deleted = true WHERE id = ?")
+@SQLRestriction(value = "is_deleted = false")
+class MemberIconEntity (
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member")
+    val member : SocialMemberEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "icon")
+    val icon : IconEntity,
+
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/model/SocialMemberEntity.kt
@@ -2,6 +2,8 @@ package kr.zziririt.zziririt.domain.member.model
 
 import jakarta.persistence.*
 import kr.zziririt.zziririt.global.entity.BaseTimeEntity
+import kr.zziririt.zziririt.global.exception.ErrorCode
+import kr.zziririt.zziririt.global.exception.RestApiException
 
 @Entity
 @Table(name = "social_member")
@@ -30,13 +32,28 @@ class SocialMemberEntity(
     @ElementCollection
     @CollectionTable(name = "member_subscriptions", joinColumns = [JoinColumn(name = "social_member_id")])
     @Column(name = "subscribe_board_id")
-    val subscribeBoardsList: MutableList<Long> = mutableListOf()
+    val subscribeBoardsList: MutableList<Long> = mutableListOf(),
+
+    @Column(name = "point", nullable = false)
+    var point: Long = 0L,
+
+    @Column(name = "default_icon", nullable = false)
+    var defaultIcon: Long = 1L,
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @Column(name = "member_icon")
+    val memberIcon: MutableList<MemberIconEntity> = mutableListOf(),
 
     ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
+    init {
+        if (this.point < 0L) {
+            throw RestApiException(ErrorCode.POINT_POLICY_VIOLATION)
+        }
+    }
 
     fun toBoardManager() {
         this.memberRole = MemberRole.BOARD_MANAGER
@@ -50,8 +67,30 @@ class SocialMemberEntity(
         this.memberStatus = MemberStatus.BANNED
     }
 
+    fun pointMinus(point: Long) {
+        this.point -= point
+    }
+
+    fun changeDefaultIcon(iconId: Long) {
+        this.defaultIcon = iconId
+    }
+
+    fun verifyPoint(point: Long): Boolean {
+        if (this.point > 0) {
+            return true
+        }
+        throw RestApiException(ErrorCode.POINT_POLICY_VIOLATION)
+    }
+
     companion object {
-        fun ofNaver(providerId: String, nickname: String, email:String, provider:String, memberRole: MemberRole, memberStatus: MemberStatus) : SocialMemberEntity {
+        fun ofNaver(
+            providerId: String,
+            nickname: String,
+            email: String,
+            provider: String,
+            memberRole: MemberRole,
+            memberStatus: MemberStatus
+        ): SocialMemberEntity {
             return SocialMemberEntity(
                 email = email,
                 nickname = nickname,

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/MemberIconRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/MemberIconRepository.kt
@@ -1,0 +1,19 @@
+package kr.zziririt.zziririt.domain.member.repository
+
+import kr.zziririt.zziririt.domain.member.model.MemberIconEntity
+import kr.zziririt.zziririt.infra.querydsl.member.dto.GetMyIconsDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+
+interface MemberIconRepository {
+
+    fun save(entity: MemberIconEntity): MemberIconEntity
+
+    fun findByIdOrNull(id: Long): MemberIconEntity?
+
+    fun getMyIcons(pageable: Pageable): PageImpl<GetMyIconsDto>
+
+    fun existsByMemberIdAndIconId(memberId: Long, iconId: Long): Boolean
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/MemberIconRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/domain/member/repository/MemberIconRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package kr.zziririt.zziririt.domain.member.repository
+
+import kr.zziririt.zziririt.domain.member.model.MemberIconEntity
+import kr.zziririt.zziririt.infra.jpa.member.MemberIconJpaRepository
+import kr.zziririt.zziririt.infra.querydsl.member.MemberIconQueryDslRepository
+import kr.zziririt.zziririt.infra.querydsl.member.dto.GetMyIconsDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+
+@Repository
+class MemberIconRepositoryImpl(
+    private val memberIconJpaRepository: MemberIconJpaRepository,
+    private val memberIconQueryDslRepository: MemberIconQueryDslRepository
+) : MemberIconRepository {
+    override fun save(entity: MemberIconEntity): MemberIconEntity = memberIconJpaRepository.save(entity)
+
+    override fun findByIdOrNull(id: Long): MemberIconEntity? = memberIconJpaRepository.findByIdOrNull(id)
+    override fun getMyIcons(pageable: Pageable): PageImpl<GetMyIconsDto> =
+        memberIconQueryDslRepository.getMyIcons(pageable)
+
+    override fun existsByMemberIdAndIconId(memberId: Long, iconId: Long): Boolean =
+        memberIconJpaRepository.existsByMemberIdAndIconId(memberId, iconId)
+
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/exception/ErrorCode.kt
@@ -10,13 +10,13 @@ enum class ErrorCode(
     UNAUTHORIZED(1001, HttpStatus.UNAUTHORIZED, "해당 API에 대한 권한이 없습니다."),
 
     POINT_POLICY_VIOLATION(4001, HttpStatus.BAD_REQUEST, "포인트는 0이상 이어야 합니다."),
+    NOT_ENOUGH_POINT(4002, HttpStatus.BAD_REQUEST, "포인트 잔액이 부족합니다."),
 
     DUPLICATE_ICON_ID(5001, HttpStatus.BAD_REQUEST, "이미 등록된 ICON입니다."),
-    NOT_ENOUGH_POINT(5002, HttpStatus.BAD_REQUEST, "포인트 잔액이 부족합니다."),
-    NOT_ENOUGH_ICONQUANTITY(5003, HttpStatus.BAD_REQUEST, "아이콘 잔여 개수가 부족합니다."),
-    NOT_FOR_SALE_STATUS(5004, HttpStatus.BAD_REQUEST, "아이콘이 판매중이 아닙니다."),
-    ALREADY_HAVE_ICON(5005, HttpStatus.BAD_REQUEST, "이미 해당 아이콘을 보유하고 있습니다."),
-    NOT_HAVE_ICON(5006, HttpStatus.BAD_REQUEST, "보유중인 아이콘이 아닙니다."),
+    NOT_ENOUGH_ICONQUANTITY(5002, HttpStatus.BAD_REQUEST, "아이콘 잔여 개수가 부족합니다."),
+    NOT_FOR_SALE_STATUS(5003, HttpStatus.BAD_REQUEST, "아이콘이 판매중이 아닙니다."),
+    ALREADY_HAVE_ICON(5004, HttpStatus.BAD_REQUEST, "이미 해당 아이콘을 보유하고 있습니다."),
+    NOT_HAVE_ICON(5005, HttpStatus.BAD_REQUEST, "보유중인 아이콘이 아닙니다."),
 
     NOT_IMAGE_FILE_EXTENSION(6101, HttpStatus.BAD_REQUEST, "png, jpeg, jpg 파일만 업로드 가능합니다."),
 

--- a/src/main/kotlin/kr/zziririt/zziririt/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/global/exception/ErrorCode.kt
@@ -9,11 +9,22 @@ enum class ErrorCode(
 ) {
     UNAUTHORIZED(1001, HttpStatus.UNAUTHORIZED, "해당 API에 대한 권한이 없습니다."),
 
+    POINT_POLICY_VIOLATION(4001, HttpStatus.BAD_REQUEST, "포인트는 0이상 이어야 합니다."),
+
+    DUPLICATE_ICON_ID(5001, HttpStatus.BAD_REQUEST, "이미 등록된 ICON입니다."),
+    NOT_ENOUGH_POINT(5002, HttpStatus.BAD_REQUEST, "포인트 잔액이 부족합니다."),
+    NOT_ENOUGH_ICONQUANTITY(5003, HttpStatus.BAD_REQUEST, "아이콘 잔여 개수가 부족합니다."),
+    NOT_FOR_SALE_STATUS(5004, HttpStatus.BAD_REQUEST, "아이콘이 판매중이 아닙니다."),
+    ALREADY_HAVE_ICON(5005, HttpStatus.BAD_REQUEST, "이미 해당 아이콘을 보유하고 있습니다."),
+    NOT_HAVE_ICON(5006, HttpStatus.BAD_REQUEST, "보유중인 아이콘이 아닙니다."),
+
     NOT_IMAGE_FILE_EXTENSION(6101, HttpStatus.BAD_REQUEST, "png, jpeg, jpg 파일만 업로드 가능합니다."),
 
     VALIDATION(9001, HttpStatus.BAD_REQUEST, "Validation을 통과하지 못했습니다."),
     MODEL_NOT_FOUND(9002, HttpStatus.BAD_REQUEST, "해당 Model을 찾지 못했습니다."),
     INVALID_TOKEN(9003, HttpStatus.UNAUTHORIZED, "JWT 검증에 실패하였습니다."),
     DUPLICATE_MODEL_NAME(9004, HttpStatus.BAD_REQUEST, "이미 존재하는 Model의 이름입니다."),
-    DUPLICATE_ROLE(9005, HttpStatus.BAD_REQUEST, "동일한 등급으로 변경할 수 없습니다.")
+    DUPLICATE_ROLE(9005, HttpStatus.BAD_REQUEST, "동일한 등급으로 변경할 수 없습니다."),
+    ITEM_POLICY_VIOLATION(9006, HttpStatus.BAD_REQUEST, "개수는 0이상 이어야 합니다."),
+
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/iconproduct/IconProductJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/iconproduct/IconProductJpaRepository.kt
@@ -1,0 +1,7 @@
+package kr.zziririt.zziririt.infra.jpa.iconproduct
+
+import kr.zziririt.zziririt.domain.iconproduct.model.IconProductEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface IconProductJpaRepository : JpaRepository<IconProductEntity, Long> {
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/member/MemberIconJpaRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/jpa/member/MemberIconJpaRepository.kt
@@ -1,0 +1,9 @@
+package kr.zziririt.zziririt.infra.jpa.member
+
+import kr.zziririt.zziririt.domain.member.model.MemberIconEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberIconJpaRepository : JpaRepository<MemberIconEntity, Long> {
+
+    fun existsByMemberIdAndIconId(memberId: Long, iconId: Long): Boolean
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/oauth2/service/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/oauth2/service/OAuth2LoginSuccessHandler.kt
@@ -30,6 +30,7 @@ class OAuth2LoginSuccessHandler(
             role = member.memberRole.toString(),
             status = memberInfo.memberStatus.toString()
         )
+        response.addHeader("Authorization", "Bearer $accessToken")
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.writer.write(accessToken)
     }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/IconProductQueryDslRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/IconProductQueryDslRepository.kt
@@ -1,0 +1,10 @@
+package kr.zziririt.zziririt.infra.querydsl.iconproduct
+
+import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.IconProductRowDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+interface IconProductQueryDslRepository {
+    fun searchBy(condition: IconSearchCondition, pageable: Pageable): PageImpl<IconProductRowDto>
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/IconProductQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/IconProductQueryDslRepositoryImpl.kt
@@ -1,0 +1,77 @@
+package kr.zziririt.zziririt.infra.querydsl.iconproduct
+
+import com.querydsl.core.types.Order
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.dsl.BooleanExpression
+import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
+import kr.zziririt.zziririt.domain.iconproduct.model.QIconShopEntity
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+import kr.zziririt.zziririt.infra.querydsl.QueryDslSupport
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.IconProductRowDto
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.QIconShopRowDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class IconProductQueryDslRepositoryImpl : IconProductQueryDslRepository, QueryDslSupport() {
+
+    private val iconProduct = QIconShopEntity.iconShopEntity
+
+    override fun searchBy(condition: IconSearchCondition, pageable: Pageable): PageImpl<IconProductRowDto> {
+        val statusCondition = iconProduct.saleStatus.`in`(
+            SaleStatus.PREPARE, SaleStatus.SALE, SaleStatus.SOLDOUT
+        )
+
+        val result = queryFactory
+            .select(
+                QIconShopRowDto(
+                    iconProduct.icon.id,
+                    iconProduct.price,
+                    iconProduct.iconQuantity,
+                    iconProduct.saleStatus
+                )
+            )
+            .from(iconProduct)
+            .where(
+                saleStatusEq(condition.searchType)
+            )
+            .orderBy(*createOrderSpecifiers(pageable))
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val count: Long = queryFactory
+            .select(iconProduct.count())
+            .from(iconProduct)
+            .where(statusCondition)
+            .fetchOne() ?: 0L
+
+        return PageImpl(result, pageable, count)
+    }
+
+    private fun saleStatusEq(saleStatus: String?): BooleanExpression? {
+        if (saleStatus.isNullOrEmpty()) {
+            return null
+        }
+        return when (saleStatus) {
+            SaleStatus.PREPARE.name -> iconProduct.saleStatus.eq(SaleStatus.PREPARE)
+            SaleStatus.SALE.name -> iconProduct.saleStatus.eq(SaleStatus.SALE)
+            SaleStatus.SOLDOUT.name -> iconProduct.saleStatus.eq(SaleStatus.SOLDOUT)
+            else -> null
+        }
+    }
+
+    private fun createOrderSpecifiers(pageable: Pageable): Array<OrderSpecifier<*>?> {
+        return pageable.sort?.let { sort ->
+            sort.mapNotNull { order ->
+                val direction = if (order.isAscending) Order.ASC else Order.DESC
+                when (order.property) {
+                    "price" -> OrderSpecifier(direction, QIconShopEntity.iconShopEntity.price)
+                    "iconQuantity" -> OrderSpecifier(direction, QIconShopEntity.iconShopEntity.iconQuantity)
+                    else -> OrderSpecifier(direction, QIconShopEntity.iconShopEntity.createdAt)
+                }
+            }.toTypedArray()
+        } ?: arrayOf()
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/IconProductQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/IconProductQueryDslRepositoryImpl.kt
@@ -4,11 +4,11 @@ import com.querydsl.core.types.Order
 import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
 import kr.zziririt.zziririt.api.iconproduct.dto.IconSearchCondition
-import kr.zziririt.zziririt.domain.iconproduct.model.QIconShopEntity
+import kr.zziririt.zziririt.domain.iconproduct.model.QIconProductEntity
 import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
 import kr.zziririt.zziririt.infra.querydsl.QueryDslSupport
 import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.IconProductRowDto
-import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.QIconShopRowDto
+import kr.zziririt.zziririt.infra.querydsl.iconproduct.dto.QIconProductRowDto
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Repository
 @Repository
 class IconProductQueryDslRepositoryImpl : IconProductQueryDslRepository, QueryDslSupport() {
 
-    private val iconProduct = QIconShopEntity.iconShopEntity
+    private val iconProduct = QIconProductEntity.iconProductEntity
 
     override fun searchBy(condition: IconSearchCondition, pageable: Pageable): PageImpl<IconProductRowDto> {
         val statusCondition = iconProduct.saleStatus.`in`(
@@ -25,7 +25,7 @@ class IconProductQueryDslRepositoryImpl : IconProductQueryDslRepository, QueryDs
 
         val result = queryFactory
             .select(
-                QIconShopRowDto(
+                QIconProductRowDto(
                     iconProduct.icon.id,
                     iconProduct.price,
                     iconProduct.iconQuantity,
@@ -67,9 +67,9 @@ class IconProductQueryDslRepositoryImpl : IconProductQueryDslRepository, QueryDs
             sort.mapNotNull { order ->
                 val direction = if (order.isAscending) Order.ASC else Order.DESC
                 when (order.property) {
-                    "price" -> OrderSpecifier(direction, QIconShopEntity.iconShopEntity.price)
-                    "iconQuantity" -> OrderSpecifier(direction, QIconShopEntity.iconShopEntity.iconQuantity)
-                    else -> OrderSpecifier(direction, QIconShopEntity.iconShopEntity.createdAt)
+                    "price" -> OrderSpecifier(direction, QIconProductEntity.iconProductEntity.price)
+                    "iconQuantity" -> OrderSpecifier(direction, QIconProductEntity.iconProductEntity.iconQuantity)
+                    else -> OrderSpecifier(direction, QIconProductEntity.iconProductEntity.createdAt)
                 }
             }.toTypedArray()
         } ?: arrayOf()

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/dto/IconProductRowDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/iconproduct/dto/IconProductRowDto.kt
@@ -1,0 +1,12 @@
+package kr.zziririt.zziririt.infra.querydsl.iconproduct.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import kr.zziririt.zziririt.domain.iconproduct.model.SaleStatus
+import java.io.Serializable
+
+data class IconProductRowDto @QueryProjection constructor(
+    val iconId: Long,
+    val price: Long,
+    val iconQuantity: Int,
+    val saleStatus: SaleStatus
+) : Serializable

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/MemberIconQueryDslRepository.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/MemberIconQueryDslRepository.kt
@@ -1,0 +1,10 @@
+package kr.zziririt.zziririt.infra.querydsl.member
+
+import kr.zziririt.zziririt.infra.querydsl.member.dto.GetMyIconsDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+interface MemberIconQueryDslRepository {
+
+    fun getMyIcons(pageable: Pageable) : PageImpl<GetMyIconsDto>
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/MemberIconQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/MemberIconQueryDslRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package kr.zziririt.zziririt.infra.querydsl.member
+
+import kr.zziririt.zziririt.domain.member.model.QMemberIconEntity
+import kr.zziririt.zziririt.infra.querydsl.QueryDslSupport
+import kr.zziririt.zziririt.infra.querydsl.member.dto.GetMyIconsDto
+import kr.zziririt.zziririt.infra.querydsl.member.dto.QGetMyIconsDto
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberIconQueryDslRepositoryImpl : MemberIconQueryDslRepository, QueryDslSupport() {
+
+    private val memberIcon = QMemberIconEntity.memberIconEntity
+    override fun getMyIcons(pageable: Pageable): PageImpl<GetMyIconsDto> {
+
+        val result = queryFactory
+            .select(
+                QGetMyIconsDto(
+                    memberIcon.member.id,
+                    memberIcon.icon.id,
+                    memberIcon.createdAt
+                )
+            )
+            .from(memberIcon)
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        val count = queryFactory
+            .select(memberIcon.count())
+            .from(memberIcon)
+            .fetchOne() ?: 0L
+
+        return PageImpl(result, pageable, count)
+    }
+}

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/SocialMemberQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/SocialMemberQueryDslRepositoryImpl.kt
@@ -13,7 +13,7 @@ class SocialMemberQueryDslRepositoryImpl : SocialMemberQueryDslRepository, Query
     private val member = QSocialMemberEntity.socialMemberEntity
     private val loginHistory = QLoginHistoryEntity.loginHistoryEntity
 
-    override fun findSleeperCandidatesMemberId() : List<Long> {
+    override fun findSleeperCandidatesMemberId(): List<Long> {
         val baseSleeperTime = LocalDateTime.now().minusYears(1)
 
         return queryFactory
@@ -26,11 +26,10 @@ class SocialMemberQueryDslRepositoryImpl : SocialMemberQueryDslRepository, Query
     }
 
     override fun bulkUpdateMemberStatusToSleeper(memberIdList: List<Long>) {
-         queryFactory
-             .update(member)
-             .set(member.memberStatus, MemberStatus.SLEEPER)
-             .where(member.id.`in`(memberIdList))
-             .execute()
+        queryFactory
+            .update(member)
+            .set(member.memberStatus, MemberStatus.SLEEPER)
+            .where(member.id.`in`(memberIdList))
+            .execute()
     }
-
 }

--- a/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/dto/GetMyIconsDto.kt
+++ b/src/main/kotlin/kr/zziririt/zziririt/infra/querydsl/member/dto/GetMyIconsDto.kt
@@ -1,0 +1,11 @@
+package kr.zziririt.zziririt.infra.querydsl.member.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.io.Serializable
+import java.time.LocalDateTime
+
+data class GetMyIconsDto @QueryProjection constructor(
+    val memberId: Long,
+    val iconId: Long,
+    val createdAt: LocalDateTime,
+) : Serializable

--- a/src/test/kotlin/kr/zziririt/zziririt/api/member/service/MemberServiceTest.kt
+++ b/src/test/kotlin/kr/zziririt/zziririt/api/member/service/MemberServiceTest.kt
@@ -1,0 +1,152 @@
+package kr.zziririt.zziririt.api.member.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.spec.style.Test
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import kr.zziririt.zziririt.api.member.controller.MemberController
+import kr.zziririt.zziririt.api.member.dto.request.AdjustRoleRequest
+import kr.zziririt.zziririt.api.member.dto.response.GetMemberResponse
+import kr.zziririt.zziririt.domain.member.model.*
+import kr.zziririt.zziririt.domain.member.repository.LoginHistoryRepository
+import kr.zziririt.zziririt.domain.member.repository.MemberIconRepository
+import kr.zziririt.zziririt.domain.member.repository.SocialMemberRepository
+import kr.zziririt.zziririt.global.exception.ModelNotFoundException
+import kr.zziririt.zziririt.global.exception.RestApiException
+import kr.zziririt.zziririt.infra.security.UserPrincipal
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import java.time.LocalDateTime
+
+@Test
+@WebMvcTest(controllers = [MemberController::class])
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureRestDocs
+class MemberServiceTest() : BehaviorSpec({
+
+    @BeforeEach
+    fun setUp() {
+        val userPrincipal = UserPrincipal(1L, "email", roles = setOf(MemberRole.ADMIN.name), "providerId")
+        val authentication = UsernamePasswordAuthenticationToken(userPrincipal, null, userPrincipal.authorities)
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+
+    val memberRepository = mockk<SocialMemberRepository>()
+    val memberIconRepository = mockk<MemberIconRepository>()
+    val loginHistoryRepository = mockk<LoginHistoryRepository>()
+    val memberService = MemberService(memberRepository, memberIconRepository, loginHistoryRepository)
+
+    val userPrincipal = UserPrincipal(1L, "email", roles = setOf(MemberRole.ADMIN.name), "providerId")
+
+
+    Given("관리자가 회원의 정보를 바꾸려고 할 때") {
+        val memberId = 1L
+        val request = AdjustRoleRequest(MemberRole.ADMIN)
+
+        val normalMemberId = 2L
+
+        When("adjustRole 매서드를 사용해서") {
+            val viewerMember = SocialMemberEntity(
+                "email",
+                "nickname",
+                OAuth2Provider.TEST,
+                "providerId",
+                MemberRole.VIEWER,
+                MemberStatus.NORMAL
+            )
+            every { memberRepository.findByIdOrNull(normalMemberId) } returns viewerMember
+
+            memberService.adjustRole(normalMemberId, request, userPrincipal)
+
+            Then("유저 정보를 변경할 할 수 있다. 여기서는 Admin으로 변경함") {
+                viewerMember.memberRole shouldBe MemberRole.ADMIN
+                //멤버 등급이 변경되지 않으면 안된다.
+                viewerMember.memberRole shouldNotBe MemberRole.VIEWER
+                //ADMIN이 아니라 BOARD_MANAGER로 변경되면 안된다.
+                viewerMember.memberRole shouldNotBe MemberRole.BOARD_MANAGER
+                //ADMIN이 아니라 STREAMER로 변경되면 안된다.
+                viewerMember.memberRole shouldNotBe MemberRole.STREAMER
+            }
+        }
+    }
+
+    Given("관리자가 회원의 정보를 바꾸려고 할 때2") {
+        val request = AdjustRoleRequest(MemberRole.ADMIN)
+
+        val normalMemberId = 2L
+
+        When("지정한 유저가 없는 유저라면") {
+            every { memberRepository.findByIdOrNull(normalMemberId) } returns null
+
+            Then("ModelNotFoundException 발생해야 한다.") {
+                shouldThrow<ModelNotFoundException> { memberService.adjustRole(normalMemberId, request, userPrincipal) }
+            }
+        }
+    }
+
+    Given("관리자가 회원의 정보를 바꾸려고 할 때3") {
+        val request = AdjustRoleRequest(MemberRole.VIEWER)
+
+        val normalMemberId = 2L
+
+        When("회원의 정보와 바꾸려는 정보가 이미 같다면") {
+            val viewerMember = SocialMemberEntity(
+                "email",
+                "nickname",
+                OAuth2Provider.TEST,
+                "providerId",
+                MemberRole.VIEWER,
+                MemberStatus.NORMAL
+            )
+            every { memberRepository.findByIdOrNull(normalMemberId) } returns viewerMember
+
+            Then("ModelNotFoundException 발생해야 한다.") {
+                shouldThrow<RestApiException> { memberService.adjustRole(normalMemberId, request, userPrincipal) }
+            }
+        }
+    }
+
+    Given("유저가 내 정보 조회를 할 때") {
+        When("내 정보와 토큰의 정보가 일치한다면") {
+            val testMember = SocialMemberEntity(
+                "email",
+                "nickname",
+                OAuth2Provider.TEST,
+                "providerId",
+                MemberRole.VIEWER,
+                MemberStatus.NORMAL
+            )
+            every { memberRepository.findByIdOrNull(userPrincipal.memberId) } returns testMember
+            val loginHistoryEntity =
+                LoginHistoryEntity(memberId = testMember, ip = "ip", userEnvironment = "environment")
+            loginHistoryEntity.createdAt = LocalDateTime.now()
+            every { loginHistoryRepository.findTopByMemberIdOrderByCreatedAtDesc(testMember) } returns loginHistoryEntity
+
+            Then("유저 정보가 반환되어야 한다.") {
+                GetMemberResponse(
+                    nickname = testMember.nickname,
+                    memberStatus = testMember.memberStatus,
+                    lastLogin = loginHistoryEntity.createdAt
+                )
+            }
+        }
+    }
+
+    Given("유저가 내 정보 조회를 할 때2") {
+        When("내 정보와 토큰의 정보가 일치하지 않다면") {
+            every { memberRepository.findByIdOrNull(userPrincipal.memberId) } returns null
+
+            Then("ModelNotFoundException이 발생해야 한다.") {
+                shouldThrow<ModelNotFoundException> { memberService.getMember(userPrincipal) }
+            }
+        }
+    }
+})


### PR DESCRIPTION
연관이슈
#78 

***

상세내역

ZRR-82 Feat: 포인트, 아이콘 샵 개발

1. IconController
 - 아이콘 추가 // 등록자, 등록일자 등의 관리가 필요하므로 백엔드에서 처리
 - 아이콘 삭제

2. IconEntity
 - iconName : 아이콘 이름
 - iconUrl : 해당 아이콘의 이미지Url
 - iconApplicationUrl : 아이콘 신청 게시판의 게시글 Url (수동 입력)
 - iconMaker : 아이콘 신청 게시판의 게시글 작성자의 유저 정보 (수동 입력)

3. IconSearchCondition
 - 아이콘샵에서 아이콘 동적 조회를 위한 Condition
 - validation 적용
 
4. IconService
 - icon 등록 및 삭제
 - icon 등록 시 여러 파일을 업로드할 수 있음
 
5. IconShopService
 - 아이콘 샵에 아이콘을 등록함
 - 판매 상태를 변경함 (PREPARE, SALE, SOLDOUT)
 - 아이콘 샵에 아이콘을 삭제함
 - 아이콘 샵의 아이콘을 단건 조회함
 - 아이콘 샵의 아이콘을 조회함 (page 및 동적 조회 적용)
 - 아이콘 샵의 아이콘을 구매함
 
6. IconShopQueryDsl
 - SearchType (PREPARE, SALE, SOLDOUT)에 따라 원하는 값만 검색
 - 정렬 기준을 동적으로 설정할 수 있음 (price asc, price desc, iconQuantity asc, iconQuantity Desc)
 - 정렬 기준은 중복이 가능함 (가격이 높은 순서 + 수량이 낮은 순서 등)
 
7. MemberService
 - 내가 보유 중인 아이콘을 조회하는 기능 추가
 - 내 대표 아이콘을 변경하는 기능 추가
 
8. SocialMemberEntity
 - 기본 아이콘 추가 (기본 아이콘으로 등록할 아이콘이 1L로 지정될 예정)